### PR TITLE
docs: update developer instructions

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -44,9 +44,9 @@ A GitHub Actions workflow (`.github/workflows/presubmit-tests.yml`) is triggered
 for every pull request. This workflow primarily verifies that the extension can
 be successfully installed by the Gemini CLI.
 
-Currently, there are no automated unit or integration test suites
-within this repository. All functional testing must be performed manually. All tools
-are currently tested in the [MCP Toolbox GitHub](https://github.com/googleapis/mcp-toolbox).
+All tools are currently tested in the [MCP Toolbox GitHub](https://github.com/googleapis/mcp-toolbox).
+
+The skills themselves are validated using the `skills-validate.yml` workflow.
 
 ### Other GitHub Checks
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -26,20 +26,7 @@ The core logic for this extension is handled by a pre-built `toolbox` binary. Th
     cd cloud-sql-postgresql
     ```
 
-2.  **Download the Toolbox Binary:** The required version of the `toolbox` binary
-    is specified in `toolbox_version.txt`. Download it for your platform.
-
-    ```bash
-    # Read the required version
-    VERSION=$(cat toolbox_version.txt)
-
-    # Example for macOS/amd64
-    curl -L -o toolbox https://storage.googleapis.com/mcp-toolbox-for-databases/geminicli/v$VERSION/darwin/amd64/toolbox
-    chmod +x toolbox
-    ```
-    Adjust the URL for your operating system (`linux/amd64`, `darwin/arm64`, `windows/amd64`).
-
-3.  **Install the Extension Locally:** Use the Gemini CLI to install the
+2.  **Install the Extension Locally:** Use the Gemini CLI to install the
     extension from your local directory.
 
     ```bash
@@ -47,7 +34,7 @@ The core logic for this extension is handled by a pre-built `toolbox` binary. Th
     ```
     The CLI will prompt you to confirm the installation. Accept it to proceed.
 
-4.  **Testing Changes:** After installation, start the Gemini CLI (`gemini`).
+3.  **Testing Changes:** After installation, start the Gemini CLI (`gemini`).
     You can now interact with the `cloud-sql-postgresql` tools to manually test your changes
     against your connected database.
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -17,8 +17,6 @@ Before you begin, ensure you have the following:
 
 ### Running from Local Source
 
-The core logic for this extension is handled by a pre-built `toolbox` binary. The development process involves installing the extension locally into the Gemini CLI to test changes.
-
 1.  **Clone the Repository:**
 
     ```bash


### PR DESCRIPTION
Removed instructions for downloading the toolbox binary and adjusted numbering.