### PR TITLE
docs: use `codex plugin add` for plugin installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ codex plugin marketplace add GoogleCloudPlatform/data-agent-kit
 **2. Install the plugin:**
 
 ```bash
-codex plugin install cloud-sql-postgresql@data-agent-kit
+codex plugin add cloud-sql-postgresql@data-agent-kit
 ```
 
 **3. Set env vars:**


### PR DESCRIPTION
## Summary
- Update the Codex installation instructions to use `codex plugin add` instead of the wrong `codex plugin install`.

Mirrors GoogleCloudPlatform/data-agent-kit#65.